### PR TITLE
View current branch in tree mode from magit status

### DIFF
--- a/github-browse-file.el
+++ b/github-browse-file.el
@@ -97,8 +97,9 @@ Otherwise, return the name of the current  branch."
 the kill ring."
   (let ((url (concat "https://github.com/"
                      (github-browse-file--relative-url) "/"
-                     (if github-browse-file--view-blame "blame" "blob") "/"
-                     (github-browse-file--current-rev) "/"
+                     (if (eq major-mode 'magit-status-mode) "tree"
+                       (if github-browse-file--view-blame "blame" "blob"))
+                     "/" (github-browse-file--current-rev) "/"
                      (github-browse-file--repo-relative-path)
                      (when anchor (concat "#" anchor)))))
     (kill-new url)


### PR DESCRIPTION
I find it useful to open the current branch in tree mode on Github when you are in a magit status buffer instead of a 404 blob URL.
