### PR TITLE
Decf is provided if cl.el is required, cl-decf is autoloaded

### DIFF
--- a/github-browse-file.el
+++ b/github-browse-file.el
@@ -117,7 +117,7 @@ default to current line."
    ((and transient-mark-mode mark-active)
     (let ((start (line-number-at-pos (region-beginning)))
           (end (line-number-at-pos (region-end))))
-      (when (eq (char-before (region-end)) ?\n) (decf end))
+      (when (eq (char-before (region-end)) ?\n) (cl-decf end))
       (if (>= start end)
           (format "L%d" start)
         (format "L%d-%d" start end))))


### PR DESCRIPTION
Likely addresses #8, and fixes the general case of selecting regions
without requiring cl.el.
