### PR TITLE
Add `github-browse-commit`, improve magit support

### DIFF
--- a/github-browse-file.el
+++ b/github-browse-file.el
@@ -117,9 +117,9 @@ the kill ring."
                      (cond ((eq major-mode 'magit-status-mode) "tree")
                            (github-browse-file--view-blame "blame")
                            (t "blob")) "/"
-                     (github-browse-file--current-rev) "/"
-                     (github-browse-file--repo-relative-path)
-                     (when anchor (concat "#" anchor)))))
+                           (github-browse-file--current-rev) "/"
+                           (github-browse-file--repo-relative-path)
+                           (when anchor (concat "#" anchor)))))
     (kill-new url)
     (if github-browse-file-visit-url
         (browse-url url)
@@ -140,6 +140,18 @@ default to current line."
         (format "L%d-%d" start end))))
    (github-browse-file-show-line-at-point
     (format "L%d" (line-number-at-pos (point))))))
+
+(defun github-browse-file--guess-commit ()
+  "Guess the current git commit.
+If you are in any magit mode, use `magit-branch-or-commit-at-point'.
+Otherwise, if the region is active, use that.
+Otherwse, use `github-browse-file--current-rev'."
+  (cond
+   ((derived-mode-p 'magit-mode)
+    (magit-branch-or-commit-at-point))
+   ((region-active-p)
+    (buffer-substring (region-beginning) (region-end)))
+   (t (github-browse-file--current-rev))))
 
 ;;;###autoload
 (defun github-browse-file (&optional force-master)
@@ -165,6 +177,19 @@ region."
   (interactive "P")
   (let ((github-browse-file--view-blame t))
     (github-browse-file force-master)))
+
+;;;###autoload
+(defun github-browse-commit ()
+  "Show the GitHub page for the current commit."
+  (interactive)
+  (let* ((commit (github-browse-file--guess-commit))
+         (url (concat "https://github.com/"
+                      (github-browse-file--relative-url)
+                      "/commit/"
+                      commit)))
+    (if github-browse-file-visit-url
+        (browse-url url)
+      (message "GitHub: %s" url))))
 
 ;;;###autoload
 (defun github-browse-new-issue ()

--- a/github-browse-file.el
+++ b/github-browse-file.el
@@ -166,5 +166,14 @@ region."
   (let ((github-browse-file--view-blame t))
     (github-browse-file force-master)))
 
+;;;###autoload
+(defun github-browse-new-issue ()
+  "Open the new issue page for this Github repository."
+  (interactive)
+  (let ((url (concat "https://github.com/"
+                     (github-browse-file--relative-url)
+                     "/issues/new")))
+    (browse-url url)))
+
 (provide 'github-browse-file)
 ;;; github-browse-file.el ends here

--- a/github-browse-file.el
+++ b/github-browse-file.el
@@ -200,5 +200,17 @@ region."
                      "/issues/new")))
     (browse-url url)))
 
+;;;###autoload
+(defun github-browse-pull-request ()
+  "Visit the current branch's comparison/pull request on Github."
+  (interactive)
+  (let ((url (concat "https://github.com/"
+                     (github-browse-file--relative-url)
+                     "/compare/"
+                     (github-browse-file--remote-branch))))
+    (if github-browse-file-visit-url
+        (browse-url url)
+      (message "GitHub: %s" url))))
+
 (provide 'github-browse-file)
 ;;; github-browse-file.el ends here


### PR DESCRIPTION
This PR adds the following updates:

* If you call `github-browse-file` from certain non-file magit modes (`magit-commit-mode`, `magit-revision-mode`, or `magit-log-mode`), it assumes you are interested in looking at the commit of the current buffer/line and uses `magit`'s internal `magit-commit-at-point`.

* Adds `github-browse-commit`, which guesses the commit in the following order:
  - If the current major mode is derived from `magit` and a commit is from `magit-commit-at-point`, use that.
  - If the region is active, it assumes that is the commit you are interested in and uses that.
  - Otherwise, it falls back to `github-browse-file--current-rev`.