### PR TITLE
Open a commit when in magit-commit-mode

### DIFF
--- a/github-browse-file.el
+++ b/github-browse-file.el
@@ -115,6 +115,7 @@ the kill ring."
   (let ((url (concat "https://github.com/"
                      (github-browse-file--relative-url) "/"
                      (cond ((eq major-mode 'magit-status-mode) "tree")
+                           ((eq major-mode 'magit-commit-mode) "commit")
                            (github-browse-file--view-blame "blame")
                            (t "blob")) "/"
                      (github-browse-file--current-rev) "/"


### PR DESCRIPTION
Without this change, if you run github-browse-file in a
magit-commit-mode buffer, you go to /blog/sha which is a 404. This
change recognises that mode and sends the user to the commit on github.