### PR TITLE
When in magit-commit-mode go to that commit

### DIFF
--- a/github-browse-file.el
+++ b/github-browse-file.el
@@ -105,6 +105,10 @@ If github-browse-file--force-master is non-nil, return \"master\".
 Otherwise, return the name of the current  branch."
   (cond
    (github-browse-file--force-master "master")
+   ((eq major-mode 'magit-commit-mode)
+    (save-excursion
+      (beginning-of-buffer)
+      (thing-at-point 'word t)))
    ((github-browse-file--ahead-p) (github-browse-file--remote-branch))
    (t (let ((rev (vc-git--run-command-string nil "rev-parse" "HEAD")))
         (and rev (replace-regexp-in-string "\n" "" rev))))))


### PR DESCRIPTION
Instead of going to the commit your repository is at, if you have a
magit-commit buffer open (viewing some history), go to that commit.

For example: View status of your repository in magit, then look at the
log, then move your cursor to a commit and press enter to view the
commit. At this point when you invoke github-browse-file what you expect
to happen is likely "go to this commit I'm looking at, on github".
That's what this change should do.