### PR TITLE
Replace 'beginning-of-buffer' with 'goto-char'

### DIFF
--- a/github-browse-file.el
+++ b/github-browse-file.el
@@ -107,7 +107,7 @@ Otherwise, return the name of the current  branch."
    (github-browse-file--force-master "master")
    ((eq major-mode 'magit-commit-mode)
     (save-excursion
-      (beginning-of-buffer)
+      (goto-char (point-min))
       (thing-at-point 'word t)))
    ((github-browse-file--ahead-p) (github-browse-file--remote-branch))
    (t (let ((rev (vc-git--run-command-string nil "rev-parse" "HEAD")))


### PR DESCRIPTION
There is a compilation warning:

    `beginning-of-buffer' is for interactive use only; use `(goto-char (point-min))' instead.

`C-h f beginning-of-buffer` also tells "Don't use this command in Lisp programs!".
