### PR TITLE
Fix Marmalade and MELPA URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ View the file you're editing in Emacs on GitHub.
 
 ### Installation:
 
-Available as a package in [Marmalade](http://marmalade-repo.org/) and [MELPA](http://melpa.milkbox.net/).
+Available as a package in [Marmalade](https://marmalade-repo.org/) and [MELPA](http://melpa.org/).
 
 `M-x package-install github-browse-file`
 


### PR DESCRIPTION
Marmalade is `https` now and MELPA was moved.
