### PR TITLE
Save commit url to kill ring

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Call `github-browse-file` (for the git blob) or `github-browse-file-blame`
 (for the git blame) to view current file on GitHub. With a prefix argument
 (`C-u`), you can force them to use the "master" branch.
 
+`github-browse-commit` can be used to link to the current commit.
+
 For more information see [my blog post](http://ozansener.com/blog/view-the-file-youre-editing-in-emacs-on-github/).
 
 ### Contributors

--- a/github-browse-file.el
+++ b/github-browse-file.el
@@ -127,10 +127,7 @@ the kill ring."
                            (github-browse-file--current-rev) "/"
                            (github-browse-file--repo-relative-path)
                            (when anchor (concat "#" anchor)))))
-    (kill-new url)
-    (if github-browse-file-visit-url
-        (browse-url url)
-      (message "GitHub: %s" url))))
+    (github-browse--save-and-view url)))
 
 (defun github-browse-file--anchor-lines ()
   "Calculate anchor from lines in active region or current line
@@ -159,6 +156,13 @@ Otherwse, use `github-browse-file--current-rev'."
    ((region-active-p)
     (buffer-substring (region-beginning) (region-end)))
    (t (github-browse-file--current-rev))))
+
+(defun github-browse--save-and-view (url)
+  "Save url to kill ring and browse or show the url"
+  (kill-new url)
+  (if github-browse-file-visit-url
+      (browse-url url)
+    (message "GitHub: %s" url)))
 
 ;;;###autoload
 (defun github-browse-file (&optional force-master)
@@ -194,10 +198,7 @@ region."
                       (github-browse-file--relative-url)
                       "/commit/"
                       commit)))
-    (kill-new url)
-    (if github-browse-file-visit-url
-        (browse-url url)
-      (message "GitHub: %s" url))))
+    (github-browse--save-and-view url)))
 
 (provide 'github-browse-file)
 ;;; github-browse-file.el ends here

--- a/github-browse-file.el
+++ b/github-browse-file.el
@@ -194,6 +194,7 @@ region."
                       (github-browse-file--relative-url)
                       "/commit/"
                       commit)))
+    (kill-new url)
     (if github-browse-file-visit-url
         (browse-url url)
       (message "GitHub: %s" url))))


### PR DESCRIPTION
github-browse-commit was not saving the url to the kill ring like it does in github-browse-file https://github.com/osener/github-browse-file/blob/master/github-browse-file.el#L130

Also added some documentation mentioning github-browse-commit, and DRYed up the kill/browse/view logic.
